### PR TITLE
SP-3081 update credentialing template

### DIFF
--- a/mandrill/credentialing-alerts-staging.html
+++ b/mandrill/credentialing-alerts-staging.html
@@ -642,10 +642,7 @@
                                                                               </div>
                                                                                
                                                                               <div>
-                                                                                  {{#if this.person.credentialing_expiry_date}} Expired {{this.person.credentialing_role}} {{#if `this.person.credentialing_role == "CNA"`}} Certificate{{/if}}
-{{#unless `this.person.credentialing_role == "CNA"`}} License{{/unless}} {{this.person.credentialing_expiry_date}} {{/if}}
-                                                                                  {{#unless this.person.credentialing_expiry_date}} Missing {{this.person.credentialing_role}} {{#if `this.person.credentialing_role == "CNA"`}} Certificate{{/if}}
-{{#unless `this.person.credentialing_role == "CNA"`}} License{{/unless}}{{/unless}} 
+                                                                                  {{this.person.credential_message}} 
                                                                               </div>
                                                                           </td>
                                                                       </tr>
@@ -705,8 +702,7 @@
                                                                               </div>
                                                                                
                                                                               <div>
-                                                                                  Invalid {{this.person.credentialing_role}} {{#if `this.person.credentialing_role == "CNA"`}} Certificate{{/if}}
-{{#unless `this.person.credentialing_role == "CNA"`}} License{{/unless}}
+                                                                                  {{this.person.credential_message}}
                                                                               </div>
                                                                           </td>
                                                                       </tr>
@@ -765,8 +761,7 @@
                                                                               </div>
                                                                                
                                                                               <div>
-                                                                                 {{this.person.credentialing_role}}{{#if `this.person.credentialing_role == "CNA"`}} Certificate{{/if}}
-{{#unless `this.person.credentialing_role == "CNA"`}} License{{/unless}}
+                                                                                 {{this.person.credential_message}}
                                                                               </div>
                                                                           </td>
                                                                       </tr>
@@ -785,11 +780,121 @@
                                                     </table>  
                                                 </td>
                                             </tr>
-                                            </tbody>
-                                        </table>
-                                        </td>
-                                        </tr>
-                                        
+                                            {{#if show_pending_credentials}}
+                                            <!-- PENDING LICENSES // -->
+                                            <table align="left" border="0" cellpadding="0" cellspacing="0" width="600" class="mcnTextContentContainer">
+                                                <tbody>
+                                                <tr>
+                                                    <td valign="top" class="mcnTextContent section-title" style="padding-top:30px; padding-bottom: 9px;">
+                                                    <div class="number-badge {{#if `pending_count == 0`}} green {{else}} red {{/if}}"><div>{{pending_count}}</div></div>
+                                                    <div class="title-name"><b>Employees have Pending Credentials</b></div>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <table class="employees-table">
+                                                            <tbody>
+                                                                {{#if `pending_count == 0`}}
+                                                                    
+                                                                        <tr>
+                                                                            <td class="single-row employee-name">
+                                                                                No Pending Credentials  🎉
+                                                                            </td>
+                                                                        </tr>
+                                                                {{/if}}
+                                                                {{#each pending_credentials}}
+                                                                    {{#each this}}
+                                                                        {{#if `@index < 5`}}
+                                                                          <tr>
+                                                                              <td class="employee-name {{#if `@index == 0`}} top-left-corner {{/if}} {{#if `@index == pending_count - 1`}} bottom-left-corner bottom-row {{/if}}">
+                                                                                {{this.person.first_name}} {{this.person.last_name}}
+                                                                              </td>
+                                                                              <td class="credential-info {{#if `@index == 0`}} top-right-corner {{/if}} {{#if `@index == pending_count - 1`}} bottom-right-corner bottom-row {{/if}}">
+                                                                                  <div>
+                                                                                    <img class="icon" src="https://dxdvdfdpzm7x7.cloudfront.net/hourglass-icon.png">
+                                                                                </div>
+                                                                                  <div>
+                                                                                      {{this.person.credential_message}}
+                                                                                  </div>
+                                                                              </td>
+                                                                          </tr>
+                                                                        {{/if}}
+                                                                    {{/each}}
+                                                                {{/each}}
+                                                                {{#if `pending_count > 5` }}
+                                                                  <tr class="see-all-link">
+                                                                      <td colspan="2" class="bottom-left-corner bottom-right-corner">
+                                                                          {{`pending_count - 5`}} more employees...
+                                                                          <a href="{{see_all_url}}" target="_blank">See All</a>
+                                                                      </td>
+                                                                  </tr>
+                                                                {{/if}}
+                                                            </tbody>
+                                                        </table>  
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                            </td>
+                                            </tr>
+                                            <tr>
+                                            <td valign="top" class="mcnTextBlockInner">
+                                        {{/if}}
+                                        <!-- FAILED LICENSES // -->
+                                            <table align="left" border="0" cellpadding="0" cellspacing="0" width="600" class="mcnTextContentContainer">
+                                                <tbody>
+                                                <tr>
+                                                    <td valign="top" class="mcnTextContent section-title" style="padding-top:30px; padding-bottom: 9px;">
+                                                    <div class="number-badge {{#if `failed_count == 0`}} green {{else}} red {{/if}}"><div>{{failed_count}}</div></div>
+                                                    <div class="title-name"><b>Employees have Credentials that Failed Validation</b></div>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <table class="employees-table">
+                                                            <tbody>
+                                                                {{#if `failed_count == 0`}}
+                                                                    
+                                                                        <tr>
+                                                                            <td class="single-row employee-name">
+                                                                                No Failed Credentials  🎉
+                                                                            </td>
+                                                                        </tr>
+                                                                {{/if}}
+                                                                {{#each failed_credentials}}
+                                                                    {{#each this}}
+                                                                        {{#if `@index < 5`}}
+                                                                          <tr>
+                                                                              <td class="employee-name {{#if `@index == 0`}} top-left-corner {{/if}} {{#if `@index == failed_count - 1`}} bottom-left-corner bottom-row {{/if}}">
+                                                                                {{this.person.first_name}} {{this.person.last_name}}
+                                                                              </td>
+                                                                              <td class="credential-info {{#if `@index == 0`}} top-right-corner {{/if}} {{#if `@index == failed_count - 1`}} bottom-right-corner bottom-row {{/if}}">
+                                                                                  <div>
+                                                                                      {{this.person.credential_message}}
+                                                                                  </div>
+                                                                              </td>
+                                                                          </tr>
+                                                                        {{/if}}
+                                                                    {{/each}}
+                                                                {{/each}}
+                                                                {{#if `failed_count > 5` }}
+                                                                  <tr class="see-all-link">
+                                                                      <td colspan="2" class="bottom-left-corner bottom-right-corner">
+                                                                          {{`failed_count - 5`}} more employees...
+                                                                          <a href="{{see_all_url}}" target="_blank">See All</a>
+                                                                      </td>
+                                                                  </tr>
+                                                                {{/if}}
+                                                            </tbody>
+                                                        </table>  
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                            </td>
+                                            </tr>
+                                            <tr>
+                                            <td valign="top" class="mcnTextBlockInner">
                                         <!-- LICENSES EXPIRING SOON // -->
                                         <tr>
                                             <td class="mcnTextBlockInner">
@@ -843,8 +948,7 @@
                                                                                             </div>
                                                                                              
                                                                                             <div>
-                                                                                                {{this.person.credentialing_role}} {{#if `this.person.credentialing_role == "CNA"`}} Certificate{{/if}}
-{{#unless `this.person.credentialing_role == "CNA"`}} License{{/unless}} Expiring {{this.person.credentialing_expiry_date}}
+                                                                                                {{this.person.credential_message}}
                                                                                             </div>
                                                                                         </td>
                                                                                     </tr>
@@ -886,8 +990,7 @@
                                                                                             </div>
                                                                                              
                                                                                             <div>
-                                                                                                {{this.person.credentialing_role}} {{#if `this.person.credentialing_role == "CNA"`}} Certificate{{/if}}
-{{#unless `this.person.credentialing_role == "CNA"`}} License{{/unless}} Expiring {{this.person.credentialing_expiry_date}}
+                                                                                                {{this.person.credential_message}}
                                                                                             </div>
                                                                                         </td>
                                                                                     </tr>
@@ -929,8 +1032,7 @@
                                                                                             </div>
                                                                                              
                                                                                             <div>
-                                                                                                {{this.person.credentialing_role}} {{#if `this.person.credentialing_role == "CNA"`}} Certificate{{/if}}
-{{#unless `this.person.credentialing_role == "CNA"`}} License{{/unless}} Expiring {{this.person.credentialing_expiry_date}}
+                                                                                                {{this.person.credential_message}}
                                                                                             </div>
                                                                                         </td>
                                                                                     </tr>

--- a/mandrill/credentialing-alerts.html
+++ b/mandrill/credentialing-alerts.html
@@ -613,7 +613,7 @@
                                             <tr>
                                                 <td valign="top" class="mcnTextContent section-title" style="padding-top:30px; padding-bottom: 9px;">
                                                 <div class="number-badge {{#if `total_missing_or_expired_credentials == 0`}} green {{else}} red {{/if}}"><div>{{total_missing_or_expired_credentials}}</div></div>
-                                                <div class="title-name"><b>Employees have Missing or Expired Licenses</b></div>
+                                                <div class="title-name"><b>Employees have Missing or Expired Credentials</b></div>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -624,7 +624,7 @@
                                                                 {{#if `total_expiring_soon_credentials == 0`}}
                                                                     <tr>
                                                                         <td class="single-row employee-name">
-                                                                            All {{total_credentials}} Employee Licenses are Active  🎉
+                                                                            All {{total_credentials}} Employee Credentials are Active  🎉
                                                                         </td>
                                                                     </tr>
                                                                 {{/if}}
@@ -642,8 +642,7 @@
                                                                               </div>
                                                                                
                                                                               <div>
-                                                                                  {{#if this.person.credentialing_expiry_date}} Expired {{this.person.credentialing_role}} License {{this.person.credentialing_expiry_date}} {{/if}}
-                                                                                  {{#unless this.person.credentialing_expiry_date}} Missing {{this.person.credentialing_role}} License{{/unless}} 
+                                                                                  {{this.person.credential_message}} 
                                                                               </div>
                                                                           </td>
                                                                       </tr>
@@ -666,6 +665,236 @@
                                         </table>
                                         </td>
                                         </tr>
+                                        
+                                        <tr>
+                                        <td valign="top" class="mcnTextBlockInner">
+                                        <!-- INVALID LICENSES // -->
+                                        <table align="left" border="0" cellpadding="0" cellspacing="0" width="600" class="mcnTextContentContainer">
+                                            <tbody>
+                                            <tr>
+                                                <td valign="top" class="mcnTextContent section-title" style="padding-top:30px; padding-bottom: 9px;">
+                                                <div class="number-badge {{#if `invalid_count == 0`}} green {{else}} red {{/if}}"><div>{{invalid_count}}</div></div>
+                                                <div class="title-name"><b>Employees have Invalid Credentials</b></div>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>
+                                                    <table class="employees-table">
+                                                        <tbody>
+                                                            {{#if `invalid_count == 0`}}
+                                                                
+                                                                    <tr>
+                                                                        <td class="single-row employee-name">
+                                                                            No Invalid Credentials  🎉
+                                                                        </td>
+                                                                    </tr>
+                                                            {{/if}}
+                                                            {{#each invalid_credentials}}
+                                                                {{#each this}}
+                                                                    {{#if `@index < 5`}}
+                                                                      <tr>
+                                                                          <td class="employee-name {{#if `@index == 0`}} top-left-corner {{/if}} {{#if `@index == invalid_count - 1`}} bottom-left-corner bottom-row {{/if}}">
+                                                                            {{this.person.first_name}} {{this.person.last_name}}
+                                                                          </td>
+                                                                          <td class="credential-info {{#if `@index == 0`}} top-right-corner {{/if}} {{#if `@index == invalid_count - 1`}} bottom-right-corner bottom-row {{/if}}">
+                                                                              <div>
+                                                                                  <img class="icon" src="https://dxdvdfdpzm7x7.cloudfront.net/red-icon.png">
+                                                                              </div>
+                                                                               
+                                                                              <div>
+                                                                                  {{this.person.credential_message}}
+                                                                              </div>
+                                                                          </td>
+                                                                      </tr>
+                                                                    {{/if}}
+                                                                {{/each}}
+                                                            {{/each}}
+                                                            {{#if `invalid_count > 5` }}
+                                                              <tr class="see-all-link">
+                                                                  <td colspan="2" class="bottom-left-corner bottom-right-corner">
+                                                                      {{`invalid_count - 5`}} more employees...
+                                                                      <a href="{{see_all_url}}" target="_blank">See All</a>
+                                                                  </td>
+                                                              </tr>
+                                                            {{/if}}
+                                                        </tbody>
+                                                    </table>  
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                        </td>
+                                        </tr>
+                                        <tr>
+                                        <td valign="top" class="mcnTextBlockInner">
+                                        <!-- LICENSES IN REVIEW // -->
+                                        <table align="left" border="0" cellpadding="0" cellspacing="0" width="600" class="mcnTextContentContainer">
+                                            <tbody>
+                                            <tr>
+                                                <td valign="top" class="mcnTextContent section-title" style="padding-top:30px; padding-bottom: 9px;">
+                                                <div class="number-badge green"><div>{{in_review_count}}</div></div>
+                                                <div class="title-name"><b>Employees have Credentials to Review</b></div>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>
+                                                    <table class="employees-table">
+                                                        <tbody>
+                                                            {{#if `in_review_count == 0`}}
+                                                                
+                                                                    <tr>
+                                                                        <td class="single-row employee-name">
+                                                                            No Credentials to Review  🎉
+                                                                        </td>
+                                                                    </tr>
+                                                            {{/if}}
+                                                            {{#each in_review_credentials}}
+                                                                {{#each this}}
+                                                                    {{#if `@index < 5`}}
+                                                                      <tr>
+                                                                          <td class="employee-name {{#if `@index == 0`}} top-left-corner {{/if}} {{#if `@index == in_review_count - 1`}} bottom-left-corner bottom-row {{/if}}">
+                                                                            {{this.person.first_name}} {{this.person.last_name}}
+                                                                          </td>
+                                                                          <td class="credential-info {{#if `@index == 0`}} top-right-corner {{/if}} {{#if `@index == in_review_count - 1`}} bottom-right-corner bottom-row {{/if}}">
+                                                                              <div>
+                                                                                  <img class="icon" src="https://dxdvdfdpzm7x7.cloudfront.net/in_review_cred_icon.jpeg">
+                                                                              </div>
+                                                                               
+                                                                              <div>
+                                                                                 {{this.person.credential_message}}
+                                                                              </div>
+                                                                          </td>
+                                                                      </tr>
+                                                                    {{/if}}
+                                                                {{/each}}
+                                                            {{/each}}
+                                                            {{#if `in_review_count > 5` }}
+                                                              <tr class="see-all-link">
+                                                                  <td colspan="2" class="bottom-left-corner bottom-right-corner">
+                                                                      {{`in_review_count - 5`}} more employees...
+                                                                      <a href="{{see_all_url}}" target="_blank">See All</a>
+                                                                  </td>
+                                                              </tr>
+                                                            {{/if}}
+                                                        </tbody>
+                                                    </table>  
+                                                </td>
+                                            </tr>
+                                            {{#if show_pending_credentials}}
+                                            <!-- PENDING LICENSES // -->
+                                            <table align="left" border="0" cellpadding="0" cellspacing="0" width="600" class="mcnTextContentContainer">
+                                                <tbody>
+                                                <tr>
+                                                    <td valign="top" class="mcnTextContent section-title" style="padding-top:30px; padding-bottom: 9px;">
+                                                    <div class="number-badge {{#if `pending_count == 0`}} green {{else}} red {{/if}}"><div>{{pending_count}}</div></div>
+                                                    <div class="title-name"><b>Employees have Pending Credentials</b></div>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <table class="employees-table">
+                                                            <tbody>
+                                                                {{#if `pending_count == 0`}}
+                                                                    
+                                                                        <tr>
+                                                                            <td class="single-row employee-name">
+                                                                                No Pending Credentials  🎉
+                                                                            </td>
+                                                                        </tr>
+                                                                {{/if}}
+                                                                {{#each pending_credentials}}
+                                                                    {{#each this}}
+                                                                        {{#if `@index < 5`}}
+                                                                          <tr>
+                                                                              <td class="employee-name {{#if `@index == 0`}} top-left-corner {{/if}} {{#if `@index == pending_count - 1`}} bottom-left-corner bottom-row {{/if}}">
+                                                                                {{this.person.first_name}} {{this.person.last_name}}
+                                                                              </td>
+                                                                              <td class="credential-info {{#if `@index == 0`}} top-right-corner {{/if}} {{#if `@index == pending_count - 1`}} bottom-right-corner bottom-row {{/if}}">
+                                                                                  <div>
+                                                                                    <img class="icon" src="https://dxdvdfdpzm7x7.cloudfront.net/hourglass-icon.png">
+                                                                                </div>
+                                                                                  <div>
+                                                                                      {{this.person.credential_message}}
+                                                                                  </div>
+                                                                              </td>
+                                                                          </tr>
+                                                                        {{/if}}
+                                                                    {{/each}}
+                                                                {{/each}}
+                                                                {{#if `pending_count > 5` }}
+                                                                  <tr class="see-all-link">
+                                                                      <td colspan="2" class="bottom-left-corner bottom-right-corner">
+                                                                          {{`pending_count - 5`}} more employees...
+                                                                          <a href="{{see_all_url}}" target="_blank">See All</a>
+                                                                      </td>
+                                                                  </tr>
+                                                                {{/if}}
+                                                            </tbody>
+                                                        </table>  
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                            </td>
+                                            </tr>
+                                            <tr>
+                                            <td valign="top" class="mcnTextBlockInner">
+                                        {{/if}}
+                                        <!-- FAILED LICENSES // -->
+                                            <table align="left" border="0" cellpadding="0" cellspacing="0" width="600" class="mcnTextContentContainer">
+                                                <tbody>
+                                                <tr>
+                                                    <td valign="top" class="mcnTextContent section-title" style="padding-top:30px; padding-bottom: 9px;">
+                                                    <div class="number-badge {{#if `failed_count == 0`}} green {{else}} red {{/if}}"><div>{{failed_count}}</div></div>
+                                                    <div class="title-name"><b>Employees have Credentials that Failed Validation</b></div>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <table class="employees-table">
+                                                            <tbody>
+                                                                {{#if `failed_count == 0`}}
+                                                                    
+                                                                        <tr>
+                                                                            <td class="single-row employee-name">
+                                                                                No Failed Credentials  🎉
+                                                                            </td>
+                                                                        </tr>
+                                                                {{/if}}
+                                                                {{#each failed_credentials}}
+                                                                    {{#each this}}
+                                                                        {{#if `@index < 5`}}
+                                                                          <tr>
+                                                                              <td class="employee-name {{#if `@index == 0`}} top-left-corner {{/if}} {{#if `@index == failed_count - 1`}} bottom-left-corner bottom-row {{/if}}">
+                                                                                {{this.person.first_name}} {{this.person.last_name}}
+                                                                              </td>
+                                                                              <td class="credential-info {{#if `@index == 0`}} top-right-corner {{/if}} {{#if `@index == failed_count - 1`}} bottom-right-corner bottom-row {{/if}}">
+                                                                                  <div>
+                                                                                      {{this.person.credential_message}}
+                                                                                  </div>
+                                                                              </td>
+                                                                          </tr>
+                                                                        {{/if}}
+                                                                    {{/each}}
+                                                                {{/each}}
+                                                                {{#if `failed_count > 5` }}
+                                                                  <tr class="see-all-link">
+                                                                      <td colspan="2" class="bottom-left-corner bottom-right-corner">
+                                                                          {{`failed_count - 5`}} more employees...
+                                                                          <a href="{{see_all_url}}" target="_blank">See All</a>
+                                                                      </td>
+                                                                  </tr>
+                                                                {{/if}}
+                                                            </tbody>
+                                                        </table>  
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                            </td>
+                                            </tr>
+                                            <tr>
+                                            <td valign="top" class="mcnTextBlockInner">
                                         <!-- LICENSES EXPIRING SOON // -->
                                         <tr>
                                             <td class="mcnTextBlockInner">
@@ -677,7 +906,7 @@
                                                                 <div class="number-badge {{#if `total_expiring_soon_credentials == 0`}} green {{else}} yellow {{/if}}">
                                                                     <div>{{total_expiring_soon_credentials}}</div>
                                                                 </div>
-                                                                <div class="title-name"><b>Employees have Licenses Expiring soon</b></div>
+                                                                <div class="title-name"><b>Employees have Credentials Expiring soon</b></div>
                                                             </td>
                                                         </tr>
                                                         {{#if `total_expiring_soon_credentials == 0`}}
@@ -687,7 +916,7 @@
                                                                     <tbody>
                                                                         <tr>
                                                                             <td class="single-row employee-name">
-                                                                                No Licenses will Expire within 30 days 🎉
+                                                                                No Credentials will Expire within 30 days 🎉
                                                                             </td>
                                                                         </tr>
                                                                     </tbody>
@@ -699,7 +928,7 @@
                                                     {{#if `five_count > 0`}}
                                                         <tr>
                                                             <td class="subtitle">
-                                                                <h5>Licenses Expiring within 5 days:</h5>
+                                                                <h5>Credentials Expiring within 5 days:</h5>
                                                             </td>
                                                         </tr>
                                                         <tr>
@@ -719,7 +948,7 @@
                                                                                             </div>
                                                                                              
                                                                                             <div>
-                                                                                                {{this.person.credentialing_role}} License Expiring {{this.person.credentialing_expiry_date}}
+                                                                                                {{this.person.credential_message}}
                                                                                             </div>
                                                                                         </td>
                                                                                     </tr>
@@ -743,7 +972,7 @@
                                                     {{#if `fourteen_count > 0`}}
                                                         <tr>
                                                             <td class="subtitle">
-                                                                <h5>Licenses Expiring within 14 days:</h5>
+                                                                <h5>Credentials Expiring within 14 days:</h5>
                                                             </td>
                                                         </tr>
                                                         <tr>
@@ -761,7 +990,7 @@
                                                                                             </div>
                                                                                              
                                                                                             <div>
-                                                                                                {{this.person.credentialing_role}} License Expiring {{this.person.credentialing_expiry_date}}
+                                                                                                {{this.person.credential_message}}
                                                                                             </div>
                                                                                         </td>
                                                                                     </tr>
@@ -785,7 +1014,7 @@
                                                     {{#if `thirty_count > 0`}}
                                                         <tr>
                                                             <td class="subtitle">
-                                                                <h5>Licenses Expiring within 30 days:</h5>
+                                                                <h5>Credentials Expiring within 30 days:</h5>
                                                             </td>
                                                         </tr>
                                                         <tr>
@@ -803,7 +1032,7 @@
                                                                                             </div>
                                                                                              
                                                                                             <div>
-                                                                                                {{this.person.credentialing_role}} License Expiring {{this.person.credentialing_expiry_date}}
+                                                                                                {{this.person.credential_message}}
                                                                                             </div>
                                                                                         </td>
                                                                                     </tr>


### PR DESCRIPTION
[Sync Credentialing Templates](https://apploi.atlassian.net/browse/SP-3081)


This pull request includes significant changes to the `mandrill/credentialing-alerts-staging.html` and `mandrill/credentialing-alerts.html` files to streamline the credentialing alerts by consolidating various credential messages into a single `credential_message` field and adding new sections for pending and failed credentials.

Improvements to credentialing alerts:

* Consolidated various credential messages into a single `credential_message` field across multiple sections in `mandrill/credentialing-alerts-staging.html` and `mandrill/credentialing-alerts.html`. This change simplifies the template and reduces redundancy. [[1]](diffhunk://#diff-7d398c7c32dd945b7dab0631cdc18de2abc54d66eccb782312dd8eea651e0a7bL645-R645) [[2]](diffhunk://#diff-7d398c7c32dd945b7dab0631cdc18de2abc54d66eccb782312dd8eea651e0a7bL708-R705) [[3]](diffhunk://#diff-7d398c7c32dd945b7dab0631cdc18de2abc54d66eccb782312dd8eea651e0a7bL768-R764) [[4]](diffhunk://#diff-7d398c7c32dd945b7dab0631cdc18de2abc54d66eccb782312dd8eea651e0a7bR783-R897) [[5]](diffhunk://#diff-7d398c7c32dd945b7dab0631cdc18de2abc54d66eccb782312dd8eea651e0a7bL846-R951) [[6]](diffhunk://#diff-7d398c7c32dd945b7dab0631cdc18de2abc54d66eccb782312dd8eea651e0a7bL889-R993) [[7]](diffhunk://#diff-7d398c7c32dd945b7dab0631cdc18de2abc54d66eccb782312dd8eea651e0a7bL932-R1035) [[8]](diffhunk://#diff-7d398c7c32dd945b7dab0631cdc18de2abc54d66eccb782312dd8eea651e0a7bL645-R645)

New sections for pending and failed credentials:

* Added a section to display pending credentials, which includes a count of pending credentials and a table listing employees with pending credentials. This section is only shown if `show_pending_credentials` is true.
* Added a section to display credentials that failed validation, including a count of failed credentials and a table listing employees with failed credentials. This section is only shown if there are any failed credentials.

Minor text changes:

* Updated text in `mandrill/credentialing-alerts.html` to replace "Licenses" with "Credentials" for consistency. [[1]](diffhunk://#diff-472b4f19d717facd1395d61eda885d05bc7398d479a86bf38e78a822aaaa4637L616-R616) [[2]](diffhunk://#diff-472b4f19d717facd1395d61eda885d05bc7398d479a86bf38e78a822aaaa4637L627-R627)